### PR TITLE
Add Dynmap port binding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: itzg/minecraft-server:2022.11.0-java8-jdk
     ports:
       - "${SERVER_PORT}:25565"
+      - "${HOST_DYNMAP_PORT}:8123"
     environment:
       EULA: "TRUE"
       TZ: ${TZ}


### PR DESCRIPTION
Added Dynmap Forge for server-side

- <https://github.com/webbukkit/dynmap>
- <https://www.curseforge.com/minecraft/mc-mods/dynmapforge>
- <https://e-craft.io/bukkit/plugin/dynmap/>

---

`Dynmap-3.4-forge-1.12.2.jar`を`data/FeedTheBeast/serverpack/mods/`に追加した（Mod Packは初期化用か）。
